### PR TITLE
uaelib: add memory protection allow/deny masks with debugger break

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+demoscene-toolchain (2026.06.02+1) unstable; urgency=medium
+
+  * Add MemProtect* uaelib calls.
+
+ -- Krystian Bacławski <krystian.baclawski@gmail.com>  Tue, 02 Jun 2026 09:12:32 +0200
+
 demoscene-toolchain (2025.09.21+1) unstable; urgency=medium
 
   * Add TraceEvent* uaelib calls.

--- a/patches/fs-uae/uaelib-memprotect.diff
+++ b/patches/fs-uae/uaelib-memprotect.diff
@@ -2,19 +2,44 @@ Index: demoscene-toolchain/submodules/fs-uae/src/debug.cpp
 ===================================================================
 --- demoscene-toolchain.orig/submodules/fs-uae/src/debug.cpp
 +++ demoscene-toolchain/submodules/fs-uae/src/debug.cpp
-@@ -2603,6 +2603,11 @@ struct memwatch_node mwnodes[MEMWATCH_TO
+@@ -2603,6 +2603,12 @@ struct memwatch_node mwnodes[MEMWATCH_TO
  static int mwnodes_start, mwnodes_end;
  static struct memwatch_node mwhit;
  
 +/* Memory protection (deny-by-default allow-list); see memprotect_* below. */
 +static uae_u32 **prot_tables;
 +static int memprotect_active;
-+#define PROT_BANK_LONGS (65536 / 4)
++static int memprotect_triggered;
++#define PROT_BANK_WORDS (65536 / 2)
 +
  #define MUNGWALL_SLOTS 16
  struct mungwall_data
  {
-@@ -3077,6 +3082,32 @@ static int memwatch_func (uaecptr addr,
+@@ -3059,6 +3065,23 @@ static void memwatch_hit_msg(int mw)
+ 	}
+ }
+ 
++/* Dedicated report for a memory-protection violation; mirrors memwatch_hit_msg
++ * but is clearly labelled so it isn't mistaken for a watchpoint hit. */
++static void memprotect_hit_msg(void)
++{
++	console_out_f(_T("Memprotect: break at %08X.%c %c%c%c %08X PC=%08X "), mwhit.addr,
++		mwhit.size == 1 ? 'B' : (mwhit.size == 2 ? 'W' : 'L'),
++		(mwhit.rwi & 1) ? 'R' : ' ', (mwhit.rwi & 2) ? 'W' : ' ', (mwhit.rwi & 4) ? 'I' : ' ',
++		mwhit.val, mwhit.pc);
++	for (int i = 0; memwatch_access_masks[i].mask; i++) {
++		if (mwhit.access_mask == memwatch_access_masks[i].mask)
++			console_out_f(_T("%s (%03x)\n"), memwatch_access_masks[i].name, mwhit.reg);
++	}
++	if (mwhit.access_mask & (MW_MASK_BLITTER_A | MW_MASK_BLITTER_B | MW_MASK_BLITTER_C | MW_MASK_BLITTER_D_N | MW_MASK_BLITTER_D_L | MW_MASK_BLITTER_D_F)) {
++		blitter_debugdump();
++	}
++}
++
+ static int memwatch_func (uaecptr addr, int rwi, int size, uae_u32 *valp, uae_u32 accessmask, uae_u32 reg)
+ {
+ 	uae_u32 val = *valp;
+@@ -3077,6 +3100,34 @@ static int memwatch_func (uaecptr addr,
  
  	addr = munge24 (addr);
  
@@ -22,8 +47,8 @@ Index: demoscene-toolchain/submodules/fs-uae/src/debug.cpp
 +		uae_u32 *t = prot_tables[addr >> 16];   /* addr is munge24'd; index in range */
 +		if (t) {
 +			bool denied = false;
-+			for (uaecptr a = addr; a < addr + size; a = (a & ~3) + 4) {
-+				if ((accessmask & t[(a & 0xffff) >> 2]) == 0) {
++			for (uaecptr a = addr; a < addr + size; a = (a & ~1) + 2) {
++				if ((accessmask & t[(a & 0xffff) >> 1]) == 0) {
 +					denied = true;
 +					break;
 +				}
@@ -35,6 +60,8 @@ Index: demoscene-toolchain/submodules/fs-uae/src/debug.cpp
 +				mwhit.access_mask = accessmask;
 +				mwhit.reg = reg;
 +				mwhit.val = (rwi & 2) ? val : 0;
++				mwhit.pc = M68K_GETPC;
++				memprotect_triggered = 1;
 +				debugging = 1;
 +				debug_pc = M68K_GETPC;
 +				debug_cycles ();
@@ -47,19 +74,20 @@ Index: demoscene-toolchain/submodules/fs-uae/src/debug.cpp
  	if (smc_table && (rwi >= 2))
  		smc_detector (addr, rwi, size, valp);
  
-@@ -3854,6 +3885,63 @@ static void memwatch (TCHAR **c)
+@@ -3854,6 +3905,62 @@ static void memwatch (TCHAR **c)
  	memwatch_dump (num);
  }
  
 +/*
 + * Memory protection: deny-by-default allow-list over all RAM.
 + *
-+ * prot_tables[bank][(addr & 0xffff) >> 2] holds, per longword of guest RAM, the
-+ * OR of MW_MASK_* component bits permitted to access that longword. A NULL bank
-+ * table means "not protected" (non-RAM, or not yet allocated). Once activated,
-+ * any access to a protected longword whose component bit is not set breaks into
-+ * the debugger; with nothing granted, every access to RAM breaks.
-+ * (prot_tables / memprotect_active / PROT_BANK_LONGS are declared above, before
++ * prot_tables[bank][(addr & 0xffff) >> 1] holds, per 16-bit word of guest RAM
++ * (Agnus DMA word granularity), the OR of MW_MASK_* component bits permitted to
++ * access that word. A NULL bank table means "not protected" (non-RAM, or not yet
++ * allocated). Once activated, any access to a protected word whose component bit
++ * is not set breaks into the debugger; with nothing granted, every access to RAM
++ * breaks.
++ * (prot_tables / memprotect_active / PROT_BANK_WORDS are declared above, before
 + * memwatch_func, which reads the table on the access hot path.)
 + */
 +static void memprotect_ensure_tables (void)
@@ -75,24 +103,22 @@ Index: demoscene-toolchain/submodules/fs-uae/src/debug.cpp
 +			continue;
 +		addrbank *ab = &get_mem_bank ((uaecptr)b << 16);
 +		if (ab->flags & ABFLAG_RAM)
-+			prot_tables[b] = xcalloc (uae_u32, PROT_BANK_LONGS);
++			prot_tables[b] = xcalloc (uae_u32, PROT_BANK_WORDS);
 +	}
 +}
 +
-+void memprotect_set (uaecptr addr, uae_u32 size, uae_u32 access)
++void memprotect_set (uaecptr addr, uae_u32 size, uae_u32 allow_mask, uae_u32 deny_mask)
 +{
 +	if (size == 0)
 +		return;
 +	memprotect_ensure_tables ();
-+	for (uaecptr a = addr & ~3; a < addr + size; a += 4) {
++	for (uaecptr a = addr & ~1; a < addr + size; a += 2) {
 +		uae_u32 *t = prot_tables[(a >> 16) & (membank_total - 1)];
 +		if (!t)
 +			continue;
-+		uae_u32 *slot = &t[(a & 0xffff) >> 2];
-+		if (access)
-+			*slot |= access;
-+		else
-+			*slot = 0;
++		uae_u32 *slot = &t[(a & 0xffff) >> 1];
++		*slot |= allow_mask;
++		*slot &= ~deny_mask;
 +	}
 +}
 +
@@ -111,6 +137,25 @@ Index: demoscene-toolchain/submodules/fs-uae/src/debug.cpp
  static void copymem(TCHAR **c)
  {
  	uae_u32 addr = 0, eaddr = 0, dst = 0;
+@@ -6345,7 +6452,7 @@ void debug (void)
+ 	}
+ #endif
+ 
+-	if (!memwatch_triggered) {
++	if (!memwatch_triggered && !memprotect_triggered) {
+ 		if (trace_mode) {
+ 			uae_u32 pc;
+ 			uae_u16 opcode;
+@@ -6477,6 +6584,9 @@ void debug (void)
+ 				console_out_f(_T("Breakpoint at %x\n"), pc);
+ 			debug_cycles();
+ 		}
++	} else if (memprotect_triggered) {
++		memprotect_hit_msg();
++		memprotect_triggered = 0;
+ 	} else {
+ 		memwatch_hit_msg(memwatch_triggered - 1);
+ 		memwatch_triggered = 0;
 Index: demoscene-toolchain/submodules/fs-uae/src/include/debug.h
 ===================================================================
 --- demoscene-toolchain.orig/submodules/fs-uae/src/include/debug.h
@@ -119,7 +164,7 @@ Index: demoscene-toolchain/submodules/fs-uae/src/include/debug.h
  extern struct memwatch_node mwnodes[MEMWATCH_TOTAL];
  
  extern void memwatch_dump2 (TCHAR *buf, int bufsize, int num);
-+extern void memprotect_set (uaecptr addr, uae_u32 size, uae_u32 access);
++extern void memprotect_set (uaecptr addr, uae_u32 size, uae_u32 allow_mask, uae_u32 deny_mask);
 +extern int memprotect_activate (void);
  
  uae_u16 debug_wgetpeekdma_chipram (uaecptr addr, uae_u32 v, uae_u32 mask, int reg, int ptrreg);
@@ -128,21 +173,29 @@ Index: demoscene-toolchain/submodules/fs-uae/src/uaelib.cpp
 ===================================================================
 --- demoscene-toolchain.orig/submodules/fs-uae/src/uaelib.cpp
 +++ demoscene-toolchain/submodules/fs-uae/src/uaelib.cpp
-@@ -540,6 +540,26 @@ static int native_dos_op(TrapContext *ct
+@@ -540,6 +540,34 @@ static int native_dos_op(TrapContext *ct
  
  #include "uaelib_log.cpp"
  
 +#ifdef DEBUGGER
 +/*
 + * Memory protection (deny-by-default allow-list over all RAM).
-+ * emulib_MemProtect grants (access != 0, OR of MW_MASK_* component bits) or
-+ * drops (access == 0) permission for components to touch [addr, addr+size).
++ * Permissions are tracked per 16-bit word (Agnus DMA granularity) as an OR of
++ * MW_MASK_* component bits permitted to touch each word.
++ * emulib_MemProtectAllow grants the given component bits over [addr, addr+size);
++ * emulib_MemProtectDeny revokes them (pass MW_MASK_ALL to deny the range fully).
 + * emulib_MemProtectActivate turns enforcement on, one-way: afterwards any access
-+ * to RAM whose component is not permitted for that longword breaks the debugger.
++ * to RAM whose component is not permitted for that word breaks the debugger.
 + */
-+static uae_u32 emulib_MemProtect(uae_u32 addr, uae_u32 size, uae_u32 access)
++static uae_u32 emulib_MemProtectAllow(uae_u32 addr, uae_u32 size, uae_u32 mask)
 +{
-+	memprotect_set(addr, size, access);
++	memprotect_set(addr, size, mask, 0);
++	return 0;
++}
++
++static uae_u32 emulib_MemProtectDeny(uae_u32 addr, uae_u32 size, uae_u32 mask)
++{
++	memprotect_set(addr, size, 0, mask);
 +	return 0;
 +}
 +
@@ -155,13 +208,14 @@ Index: demoscene-toolchain/submodules/fs-uae/src/uaelib.cpp
  static uae_u32 uaelib_demux_common(TrapContext *ctx, uae_u32 ARG0, uae_u32 ARG1, uae_u32 ARG2, uae_u32 ARG3, uae_u32 ARG4, uae_u32 ARG5)
  {
  	switch (ARG0) {
-@@ -565,6 +585,10 @@ static uae_u32 uaelib_demux_common(TrapC
+@@ -565,6 +593,11 @@ static uae_u32 uaelib_demux_common(TrapC
   		case 41: return emulib_WarpMode(ARG1);
   		case 42: return emulib_DebugDMA(ARG1);
   		case 43 ... 47: return emulib_TraceEvent(ARG0, ARG1, ARG2, ARG3);
 +#ifdef DEBUGGER
-+		case 48: return emulib_MemProtect(ARG1, ARG2, ARG3);
-+		case 49: return emulib_MemProtectActivate();
++		case 48: return emulib_MemProtectAllow(ARG1, ARG2, ARG3);
++		case 49: return emulib_MemProtectDeny(ARG1, ARG2, ARG3);
++		case 50: return emulib_MemProtectActivate();
 +#endif
  
  		case 68: return emulib_Minimize();

--- a/patches/fs-uae/uaelib-memprotect.diff
+++ b/patches/fs-uae/uaelib-memprotect.diff
@@ -1,0 +1,168 @@
+Index: demoscene-toolchain/submodules/fs-uae/src/debug.cpp
+===================================================================
+--- demoscene-toolchain.orig/submodules/fs-uae/src/debug.cpp
++++ demoscene-toolchain/submodules/fs-uae/src/debug.cpp
+@@ -2603,6 +2603,11 @@ struct memwatch_node mwnodes[MEMWATCH_TO
+ static int mwnodes_start, mwnodes_end;
+ static struct memwatch_node mwhit;
+ 
++/* Memory protection (deny-by-default allow-list); see memprotect_* below. */
++static uae_u32 **prot_tables;
++static int memprotect_active;
++#define PROT_BANK_LONGS (65536 / 4)
++
+ #define MUNGWALL_SLOTS 16
+ struct mungwall_data
+ {
+@@ -3077,6 +3082,32 @@ static int memwatch_func (uaecptr addr,
+ 
+ 	addr = munge24 (addr);
+ 
++	if (memprotect_active) {
++		uae_u32 *t = prot_tables[addr >> 16];   /* addr is munge24'd; index in range */
++		if (t) {
++			bool denied = false;
++			for (uaecptr a = addr; a < addr + size; a = (a & ~3) + 4) {
++				if ((accessmask & t[(a & 0xffff) >> 2]) == 0) {
++					denied = true;
++					break;
++				}
++			}
++			if (denied) {
++				mwhit.addr = addr;
++				mwhit.rwi = rwi;
++				mwhit.size = size;
++				mwhit.access_mask = accessmask;
++				mwhit.reg = reg;
++				mwhit.val = (rwi & 2) ? val : 0;
++				debugging = 1;
++				debug_pc = M68K_GETPC;
++				debug_cycles ();
++				set_special (SPCFLAG_BRK);
++				return 1;
++			}
++		}
++	}
++
+ 	if (smc_table && (rwi >= 2))
+ 		smc_detector (addr, rwi, size, valp);
+ 
+@@ -3854,6 +3885,63 @@ static void memwatch (TCHAR **c)
+ 	memwatch_dump (num);
+ }
+ 
++/*
++ * Memory protection: deny-by-default allow-list over all RAM.
++ *
++ * prot_tables[bank][(addr & 0xffff) >> 2] holds, per longword of guest RAM, the
++ * OR of MW_MASK_* component bits permitted to access that longword. A NULL bank
++ * table means "not protected" (non-RAM, or not yet allocated). Once activated,
++ * any access to a protected longword whose component bit is not set breaks into
++ * the debugger; with nothing granted, every access to RAM breaks.
++ * (prot_tables / memprotect_active / PROT_BANK_LONGS are declared above, before
++ * memwatch_func, which reads the table on the access hot path.)
++ */
++static void memprotect_ensure_tables (void)
++{
++	if (!memwatch_enabled) {
++		initialize_memwatch (0);
++		memwatch_access_validator = 0;
++	}
++	if (!prot_tables)
++		prot_tables = xcalloc (uae_u32 *, membank_total);
++	for (int b = 0; b < membank_total; b++) {
++		if (prot_tables[b])
++			continue;
++		addrbank *ab = &get_mem_bank ((uaecptr)b << 16);
++		if (ab->flags & ABFLAG_RAM)
++			prot_tables[b] = xcalloc (uae_u32, PROT_BANK_LONGS);
++	}
++}
++
++void memprotect_set (uaecptr addr, uae_u32 size, uae_u32 access)
++{
++	if (size == 0)
++		return;
++	memprotect_ensure_tables ();
++	for (uaecptr a = addr & ~3; a < addr + size; a += 4) {
++		uae_u32 *t = prot_tables[(a >> 16) & (membank_total - 1)];
++		if (!t)
++			continue;
++		uae_u32 *slot = &t[(a & 0xffff) >> 2];
++		if (access)
++			*slot |= access;
++		else
++			*slot = 0;
++	}
++}
++
++int memprotect_activate (void)
++{
++	memprotect_ensure_tables ();
++	for (int b = 0; b < membank_total; b++) {
++		addrbank *ab = &get_mem_bank ((uaecptr)b << 16);
++		if (ab->flags & ABFLAG_RAM)
++			memwatch_remap ((uaecptr)b << 16);
++	}
++	memprotect_active = 1;
++	return 0;
++}
++
+ static void copymem(TCHAR **c)
+ {
+ 	uae_u32 addr = 0, eaddr = 0, dst = 0;
+Index: demoscene-toolchain/submodules/fs-uae/src/include/debug.h
+===================================================================
+--- demoscene-toolchain.orig/submodules/fs-uae/src/include/debug.h
++++ demoscene-toolchain/submodules/fs-uae/src/include/debug.h
+@@ -165,6 +165,8 @@ struct memwatch_node {
+ extern struct memwatch_node mwnodes[MEMWATCH_TOTAL];
+ 
+ extern void memwatch_dump2 (TCHAR *buf, int bufsize, int num);
++extern void memprotect_set (uaecptr addr, uae_u32 size, uae_u32 access);
++extern int memprotect_activate (void);
+ 
+ uae_u16 debug_wgetpeekdma_chipram (uaecptr addr, uae_u32 v, uae_u32 mask, int reg, int ptrreg);
+ uae_u16 debug_wputpeekdma_chipram (uaecptr addr, uae_u32 v, uae_u32 mask, int reg, int ptrreg);
+Index: demoscene-toolchain/submodules/fs-uae/src/uaelib.cpp
+===================================================================
+--- demoscene-toolchain.orig/submodules/fs-uae/src/uaelib.cpp
++++ demoscene-toolchain/submodules/fs-uae/src/uaelib.cpp
+@@ -540,6 +540,26 @@ static int native_dos_op(TrapContext *ct
+ 
+ #include "uaelib_log.cpp"
+ 
++#ifdef DEBUGGER
++/*
++ * Memory protection (deny-by-default allow-list over all RAM).
++ * emulib_MemProtect grants (access != 0, OR of MW_MASK_* component bits) or
++ * drops (access == 0) permission for components to touch [addr, addr+size).
++ * emulib_MemProtectActivate turns enforcement on, one-way: afterwards any access
++ * to RAM whose component is not permitted for that longword breaks the debugger.
++ */
++static uae_u32 emulib_MemProtect(uae_u32 addr, uae_u32 size, uae_u32 access)
++{
++	memprotect_set(addr, size, access);
++	return 0;
++}
++
++static uae_u32 emulib_MemProtectActivate(void)
++{
++	return memprotect_activate();
++}
++#endif
++
+ static uae_u32 uaelib_demux_common(TrapContext *ctx, uae_u32 ARG0, uae_u32 ARG1, uae_u32 ARG2, uae_u32 ARG3, uae_u32 ARG4, uae_u32 ARG5)
+ {
+ 	switch (ARG0) {
+@@ -565,6 +585,10 @@ static uae_u32 uaelib_demux_common(TrapC
+  		case 41: return emulib_WarpMode(ARG1);
+  		case 42: return emulib_DebugDMA(ARG1);
+  		case 43 ... 47: return emulib_TraceEvent(ARG0, ARG1, ARG2, ARG3);
++#ifdef DEBUGGER
++		case 48: return emulib_MemProtect(ARG1, ARG2, ARG3);
++		case 49: return emulib_MemProtectActivate();
++#endif
+ 
+ 		case 68: return emulib_Minimize();
+ 		case 69: return emulib_ExecuteNativeCode();

--- a/patches/series
+++ b/patches/series
@@ -18,3 +18,4 @@ fs-uae/serial-tcpnodelay.diff
 fs-uae/serial-reliable-rx.diff
 fs-uae/uaelib-debugdma.diff
 fs-uae/uaelib-trace.diff
+fs-uae/uaelib-memprotect.diff


### PR DESCRIPTION
## Summary

Adds a deny-by-default memory protection facility to the FS-UAE debugger, exposed to guest code via three new uaelib calls. Once activated, any access to RAM that hasn't been explicitly permitted breaks into the debugger —
handy for catching rogue DMA or wild pointers.

Permissions are tracked per 16-bit word (Agnus DMA granularity) as an OR of allowed `MW_MASK_*` bits, checked on the memwatch access hot path. Violations report via a dedicated `memprotect_hit_msg()` so they aren't confused with watchpoint hits.

## New uaelib calls (gated behind `DEBUGGER`)

| # | Call | Effect |
|----|------|--------|
| 48 | `MemProtectAllow(addr, size, mask)` | grant bits over `[addr, addr+size)` |
| 49 | `MemProtectDeny(addr, size, mask)` | revoke them (`MW_MASK_ALL` = full deny) |
| 50 | `MemProtectActivate()` | turn enforcement on (one-way) |
